### PR TITLE
disable internal actor systems from crashing in cluster mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@
 name := "azure-eventhubs-reactive"
 organization := "com.microsoft.azure"
 
-version := "0.5.0"
+version := "0.5.1"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.4"
 crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 libraryDependencies ++= {

--- a/src/main/scala/com/microsoft/azure/reactiveeventhubs/Logger.scala
+++ b/src/main/scala/com/microsoft/azure/reactiveeventhubs/Logger.scala
@@ -3,10 +3,12 @@
 package com.microsoft.azure.reactiveeventhubs
 
 import akka.actor.ActorSystem
-import akka.event.{LogSource, Logging}
+import akka.event.{LogSource, Logging, LoggingAdapter}
+import com.typesafe.config.{Config, ConfigFactory}
 
 private[reactiveeventhubs] object Logger {
-  val actorSystem = ActorSystem("EventHubReact")
+  val shConfig = ConfigFactory.empty()
+  val actorSystem = ActorSystem("EventHubReact", shConfig)
 }
 
 /** Common logger via Akka
@@ -23,3 +25,4 @@ private[reactiveeventhubs] trait Logger {
 
   val log = Logging(Logger.actorSystem, this)
 }
+

--- a/src/main/scala/com/microsoft/azure/reactiveeventhubs/checkpointing/CheckpointActorSystem.scala
+++ b/src/main/scala/com/microsoft/azure/reactiveeventhubs/checkpointing/CheckpointActorSystem.scala
@@ -4,6 +4,7 @@ package com.microsoft.azure.reactiveeventhubs.checkpointing
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.language.{implicitConversions, postfixOps}
 
@@ -11,8 +12,10 @@ import scala.language.{implicitConversions, postfixOps}
   */
 private[reactiveeventhubs] case class CheckpointActorSystem(cpconfig: ICPConfiguration) {
 
-  implicit private[this] val actorSystem  = ActorSystem("EventHubReact")
+  val shConfig = ConfigFactory.empty()
+  implicit private[this] val actorSystem  = ActorSystem("EventHubReact", shConfig)
   implicit private[this] val materializer = ActorMaterializer(ActorMaterializerSettings(actorSystem))
+
   var localRegistry: Map[String, ActorRef] = Map[String, ActorRef]()
 
   /** Create an actor to read/write offset checkpoints from the storage


### PR DESCRIPTION
EventHub source used by members of an Akka cluster crashes node due to the 2 internal hardcoded actorSystems in the connector (Logging and CheckpointingActorSystem).  Akka remoting starts multiple times if akka.remote is set.  Netty Port conflicts result (2551 in use, etc...)

This stops Sinks and Flows from messaging distributed Akka actors.

PR is a workaround and I haven't dug into the implications of hiding the main Akka config from the Logging and Checkpointing actor systems yet but thought I'd share the issue.  Will be happy to find out I'm misunderstanding something.  Thx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-event-hubs-reactive/2)
<!-- Reviewable:end -->
