### PR TITLE
add a way to extract extra header valuesform systemProps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ organization := "com.microsoft.azure"
 
 version := "0.5.0"
 
-scalaVersion := "2.12.1"
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+scalaVersion := "2.12.10"
+crossScalaVersions := Seq("2.11.8", "2.12.10")
 
 libraryDependencies ++= {
   Seq(
@@ -20,7 +20,7 @@ libraryDependencies ++= {
     "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.4",
 
     // https://github.com/akka/akka/releases
-    "com.typesafe.akka" %% "akka-stream" % "2.4.17",
+    "com.typesafe.akka" %% "akka-stream" % "2.5.26",
 
     // https://github.com/json4s/json4s/releases
     "org.json4s" %% "json4s-native" % "3.5.1",

--- a/src/main/scala/com/microsoft/azure/reactiveeventhubs/EventHubsMessage.scala
+++ b/src/main/scala/com/microsoft/azure/reactiveeventhubs/EventHubsMessage.scala
@@ -45,7 +45,7 @@ class EventHubsMessage(
   // Internal properties set by Event hub stoage
   private[this] lazy val systemProps = data.get.getSystemProperties
 
-  lazy val property: String => AnyRef = (propName: => String) => systemProps.get(propName)
+  lazy val property: String => AnyRef = (propName: String) => systemProps.get(propName)
 
   // Meta properties set by the device
   lazy val properties: util.Map[String, String] = data.get.getProperties.asScala.map(x ⇒ (x._1, x._2.toString)).asJava

--- a/src/main/scala/com/microsoft/azure/reactiveeventhubs/EventHubsMessage.scala
+++ b/src/main/scala/com/microsoft/azure/reactiveeventhubs/EventHubsMessage.scala
@@ -43,10 +43,12 @@ class EventHubsMessage(
   // TODO: test properties over all protocols
 
   // Internal properties set by Event hub stoage
-  private[this] lazy val systemProps = data.get.getSystemProperties()
+  private[this] lazy val systemProps = data.get.getSystemProperties
+
+  lazy val property: String => AnyRef = (propName: => String) => systemProps.get(propName)
 
   // Meta properties set by the device
-  lazy val properties: util.Map[String, String] = data.get.getProperties().asScala.map(x ⇒ (x._1, x._2.toString)).asJava
+  lazy val properties: util.Map[String, String] = data.get.getProperties.asScala.map(x ⇒ (x._1, x._2.toString)).asJava
 
   // Time when the message was received by Event hub service. *NOT* the device time.
   lazy val received: Instant = systemProps.getEnqueuedTime
@@ -76,4 +78,5 @@ class EventHubsMessage(
         Some(partInfo.get.getLastEnqueuedOffset),
         Some(partInfo.get.getLastEnqueuedTime)))
     }
+
 }

--- a/src/test/scala/api/API.scala
+++ b/src/test/scala/api/API.scala
@@ -34,6 +34,7 @@ class APIIsBackwardCompatible
       lazy val sequenceNumber: Long = message1.sequenceNumber
       lazy val content: Array[Byte] = message1.content
       lazy val contentAsString: String = message1.contentAsString
+      lazy val extraProp: AnyRef = message1.property("test-prop")
 
       // Named parameters
       val message2: EventHubsMessage = new EventHubsMessage(data = data, partNumber = partition, partInfo = partitionInfo)


### PR DESCRIPTION
add a way to extract extra header values such as the appended ones from Azure IOT message enrichment along with updating the cross-compilation to  2.12.10 